### PR TITLE
We're currently hijacking html rendering to decode HTML entities if p…

### DIFF
--- a/src/embedded.js
+++ b/src/embedded.js
@@ -850,15 +850,20 @@
         },
 
         safeUrl: function(url) {
-            // HTML-Decode the given url if necessary
             if (url) {
                 try {
+
+                    // Security: remove script tags from URLs before processing
+                    url = url.replace(/</g, "&lt;");
+                    url = url.replace(/>/g, "&gt;");
+
+                    // HTML-Decode the given url if necessary, by rendering to the page
                     var el = document.createElement('div');
                     el.innerHTML = url;
                     var decodedUrl = el.innerText;
+
+                    // Fall back to just replacing '&amp;' in case of failure
                     if (!decodedUrl) {
-                        // It did not work (like on Firefox for example)
-                        // so fall back to just replacing '&amp;'
                         url = url.replace(/\&amp\;/g, '&');
                     }
                     else {


### PR DESCRIPTION
…resent in URLs, so we need to not be rendering any tags present as this could be an attack vector. Strip tags and replace with their entity equivalent