### PR TITLE
Make sure iFrame has pixel width for containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellosign-embedded",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "A JavaScript library required for embedding HelloSign features into your webapp. For more information, see our API documentation at https://www.hellosign.com/api/documentation.",
   "main": "src/embedded.js",
   "scripts": {

--- a/src/embedded.js
+++ b/src/embedded.js
@@ -469,6 +469,17 @@
                     styles['iframe']['border'] = 'none';
                     styles['iframe']['box-shadow'] = 'none';
                     styles['cancelButton']['display'] = 'none';
+
+                    // This is an iOS hack.  Apparently iOS ignores widths set
+                    // with a non-pixel value, which means iFrames get expanded
+                    // to the full width of their content.  Setting a pixel
+                    // value and then using `min-width` is the workaround for
+                    // this.
+                    // See:  http://stackoverflow.com/questions/23083462/how-to-get-an-iframe-to-be-responsive-in-ios-safari
+                    if (this.isMobile) {
+                        styles['iframe']['width'] = '1px';
+                        styles['iframe']['min-width'] = '100%';
+                    }
                 }
                 else if (this.isMobile) {
                     var mobileDims = this.getMobileDimensions();


### PR DESCRIPTION
When dealing with iFrames in iOS, the `width` rule is apparently ignored if it
doesn't have a pixel value.  This means that the iframe content will be expanded
to the full width of whatever the content is.  In some cases, the iframe content
is bigger than the device screen, so the iframe content overflows outside of the
viewport.  This coupled with user-disabled scrolling results in the user not
being able to get to the actual content.

Related to: DEV-2551