### PR TITLE
[DEV-4321] Add HelloSign as a global variable in AMD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hellosign-embedded",
-  "version": "1.4.2",
+  "version": "1.4.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hellosign-embedded",
-  "version": "1.4.2",
+  "version": "1.4.3-0",
   "description": "Embed HelloSign signature requests and templates from within your web application.",
   "homepage": "https://github.com/HelloFax/hellosign-embedded",
   "main": "index.js",

--- a/src/embedded.js
+++ b/src/embedded.js
@@ -984,6 +984,12 @@
         return window.pageXOffset !== undefined;
     }
 
+    // Also add HelloSign as global variable for AMD implementations.
+    // This will prevent older integrations from breaking.
+    if (typeof define === 'function' && define.amd) {
+      window.HelloSign = HelloSign;
+    }
+
     // Export the HS object
     module.exports = HelloSign;
 


### PR DESCRIPTION
Also adds HelloSign as global variable for AMD implementations. This will prevent older integrations from breaking.